### PR TITLE
http create_property assigns correct "thing"

### DIFF
--- a/dcd/bucket/thing_http.py
+++ b/dcd/bucket/thing_http.py
@@ -169,7 +169,7 @@ class ThingHTTP:
             return None
         else:
             created_property = Property(json_property=response.json())
-            created_property.belongs_to(self)
+            created_property.belongs_to(self.thing)
             self.thing.properties[created_property.property_id] = created_property
             return created_property
 


### PR DESCRIPTION
fixes issue #8 by assigning a new property to  the http_thing's thing (`created_property.belongs_to(self.thing)`) so that the property has the top level `thing`